### PR TITLE
Add Datetime support

### DIFF
--- a/c_wrapper/lua-object-generators.h
+++ b/c_wrapper/lua-object-generators.h
@@ -37,4 +37,13 @@ bool is_BSONNull(lua_State *L,
                  int index,
                  int absolute_luaBSONObjects_index);
 
+bool generate_BSONDate(lua_State *L,
+                       int64_t datetime,
+                       int absolute_luaBSONObjects_index,
+                       bson_error_t *error);
+
+bool is_BSONDate(lua_State *L,
+                 int index,
+                 int absolute_luaBSONObjects_index);
+
 #endif //MONGO_MODULE_LUA_OBJECT_GENERATORS_H

--- a/mongorover-0.1-1.rockspec
+++ b/mongorover-0.1-1.rockspec
@@ -72,6 +72,7 @@ package = "mongorover"
         ["mongorover.luaBSONObjects"] = "mongorover/luaBSONObjects.lua",
           ["mongorover.luaBSONObjects.BSONNull"] = "mongorover/luaBSONObjects/BSONNull.lua",
           ["mongorover.luaBSONObjects.ObjectId"] = "mongorover/luaBSONObjects/ObjectId.lua",
+          ["mongorover.luaBSONObjects.BSONDate"] = "mongorover/luaBSONObjects/BSONDate.lua",
         ["mongorover.resultObjects"] = "mongorover/resultObjects.lua",
           ["mongorover.resultObjects.InsertOneResult"] = "mongorover/resultObjects/InsertOneResult.lua",
           ["mongorover.resultObjects.InsertManyResult"] = "mongorover/resultObjects/InsertManyResult.lua",

--- a/mongorover/luaBSONObjects.lua
+++ b/mongorover/luaBSONObjects.lua
@@ -6,10 +6,12 @@
 
 local BSONNull = require('mongorover.luaBSONObjects.BSONNull')
 local ObjectId = require('mongorover.luaBSONObjects.ObjectId')
+local BSONDate = require('mongorover.luaBSONObjects.BSONDate')
 
 local objects = {
 	BSONNull = BSONNull,
-	ObjectId = ObjectId
+	ObjectId = ObjectId,
+	BSONDate = BSONDate
 }
 
 local luaBSONObjects = setmetatable(objects, {

--- a/mongorover/luaBSONObjects/BSONDate.lua
+++ b/mongorover/luaBSONObjects/BSONDate.lua
@@ -1,0 +1,54 @@
+--[[
+
+Copyright 2015 MongoDB, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+--]]
+
+---
+-- @submodule mongorover.luaBSONObjects
+
+--- Lua Object representing isBSONDate.
+-- @type BSONBSONDate
+
+local BSONDate = {}
+BSONDate.__index = BSONDate
+
+	function BSONDate:__tostring()
+		return "BSONDate: " .. tostring(self.datetime)
+	end
+
+	function BSONDate:__eq(a, b)
+		return BSONDate.isBSONDate(a) and BSONDate.isBSONDate(b)
+	end
+
+	---
+	-- Creates a MongoClient instance.
+	-- uses MongoDB connection URI (http://docs.mongodb.org/manual/reference/connection-string/).
+	-- @param datetime The number of seconds since the Epoch.
+	function BSONDate.new(datetime)
+		local self = setmetatable({}, BSONDate)
+		self.datetime = datetime
+		return self
+	end
+
+	---
+	-- Checks whether the object is a BSONBSONDate object or not.
+	-- @param object The object to be checked whether it is an BSONBSONDate.
+	-- @treturn bool Whether the object is an BSONBSONDate or not.
+	function BSONDate.isBSONDate(object)
+		return getmetatable(object) == BSONDate
+	end
+
+return BSONDate

--- a/test/TestCollection.lua
+++ b/test/TestCollection.lua
@@ -23,6 +23,7 @@ local BaseTest = require("BaseTest")
 
 local ObjectId = require("mongorover.luaBSONObjects.ObjectId")
 local BSONNull = require("mongorover.luaBSONObjects.BSONNull")
+local BSONDate = require("mongorover.luaBSONObjects.BSONDate")
 local InsertOneResult = require("mongorover.resultObjects.InsertOneResult")
 local InsertManyResult = require("mongorover.resultObjects.InsertManyResult")
 local UpdateResult = require("mongorover.resultObjects.UpdateResult")
@@ -58,6 +59,26 @@ setmetatable(TestCollection, {__index = BaseTest})
 		
 		local check_result = self.collection:find_one({_id = result.inserted_id})
 		lu.assertTrue(table_eq(check_result, allDifferentTypes), "insert_one and find_one documents do not match")
+	end
+
+	function TestCollection:date_conversions()
+		local seconds_before_epoch = -99
+		local epoch = 0
+		local seconds_after_epoch = 99
+
+		local dates = {
+			before_epoch = BSONDate.new(seconds_before_epoch),
+			at_epoch = BSONDate.new(epoch),
+			after_epoch = BSONDate.new(seconds_after_epoch),
+		}
+
+		self.collection:insert_one(dates)
+		local result = self.collection:find_one({}, {_id = false})
+		lu.assertEquals(result.before_epoch.datetime, seconds_before_epoch)
+		lu.assertEquals(result.at_epoch.datetime, epoch)
+		lu.assertEquals(result.after_epoch.datetime, seconds_after_epoch)
+
+		lu.assertTrue(BSONDate.isBSONDate(result.before_epoch))
 	end
 
 	function TestCollection:test_find_one_and_insert_one_without_id()


### PR DESCRIPTION
Lua usually just handles dates in seconds since the Epoch, not
milliseconds, so Datetime in this case will always refer to seconds.
See https://www.lua.org/pil/22.1.html.