### PR TITLE
Fix return value for create_index and input value for  drop_index

### DIFF
--- a/c_wrapper/lua-mongoc-collection.c
+++ b/c_wrapper/lua-mongoc-collection.c
@@ -631,13 +631,13 @@ lua_mongo_collection_destroy(lua_State *L)
 }
 
 
-
 int
 lua_mongo_collection_create_index(lua_State *L)
 {
     bool throw_error = false;
     bool created = false;
 
+    char *idxName = "";
     collection_t *collection;
     bson_t keys = BSON_INITIALIZER;
     bson_t weights = BSON_INITIALIZER;
@@ -650,53 +650,66 @@ lua_mongo_collection_create_index(lua_State *L)
     int keys_index = 3;
     int options_index = 4;
 
-    if (!(lua_istable(L, keys_index))) {
+    if(!(lua_istable(L, keys_index))){
         luaL_error(L, "keys parameter must be a table");
-    }
-
-    if (!(lua_isnil(L, keys_index))){
+    }else{
         throw_error = !(lua_table_to_bson(L, &keys, keys_index, false, absolute_luaBSONObjects_index, &error ));
         if(throw_error){
             goto DONE;
         }
+        lua_pushvalue(L, keys_index);
+        lua_pushnil(L);
+        while(lua_next(L, -2)){
+            lua_pushvalue(L, -2);
+            const char *key = lua_tostring(L, -1);
+            const char *value = lua_tostring(L, -2);
+            if(strlen(idxName) == 0){
+                asprintf(&idxName, "%s_%s", key, value);
+            }else{
+                asprintf(&idxName, "%s_%s_%s", idxName, key, value);
+            }
+            lua_pop(L, 2);
+        }
+        opt.name = idxName;
     }
 
-    if (lua_istable(L, options_index) ){
-        lua_getfield(L, options_index, "name"); //String
-        lua_getfield(L, options_index, "default_language"); //String
-        lua_getfield(L, options_index, "language_override"); //String
-        lua_getfield(L, options_index, "unique"); //Boolean
-        lua_getfield(L, options_index, "sparse"); //Boolean
-        lua_getfield(L, options_index, "background"); //Boolean
-        lua_getfield(L, options_index, "expireAfterSeconds"); //Integer
-        lua_getfield(L, options_index, "textIndexVersion"); //Integer
-        lua_getfield(L, options_index, "weights"); //Table
+    if(lua_istable(L, options_index)){
+        lua_getfield(L, options_index, "name");
+        lua_getfield(L, options_index, "default_language");
+        lua_getfield(L, options_index, "language_override");
+        lua_getfield(L, options_index, "unique");
+        lua_getfield(L, options_index, "sparse");
+        lua_getfield(L, options_index, "background");
+        lua_getfield(L, options_index, "expireAfterSeconds");
+        lua_getfield(L, options_index, "textIndexVersion");
+        lua_getfield(L, options_index, "weights");
 
-        if( lua_isstring(L, -9) ){
+        if(lua_isstring(L, -9)){
             opt.name = lua_tostring(L, -9);
+            idxName = opt.name;
         }
-        if( lua_isstring(L, -8) ){
+        if(lua_isstring(L, -8)){
             opt.default_language = lua_tostring(L, -8);
         }
-        if( lua_isstring(L, -7) ){
+        if(lua_isstring(L, -7)){
             opt.language_override = lua_tostring(L, -7);
         }
-        if( lua_isboolean(L, -6) ){
+        if(lua_isboolean(L, -6)){
             opt.unique = lua_toboolean(L, -6);
         }
-        if( lua_isboolean(L, -5) ){
+        if(lua_isboolean(L, -5)){
             opt.sparse = lua_toboolean(L, -5);
         }
-        if( lua_isboolean(L, -4) ){
+        if(lua_isboolean(L, -4)){
             opt.background = lua_toboolean(L, -4);
         }
-        if( lua_isinteger_compat(L, -3) ){
+        if(lua_isinteger_compat(L, -3)){
             opt.expire_after_seconds = lua_tointeger_compat(L, -3);
         }
-        if( lua_isinteger_compat(L, -2) ){
+        if(lua_isinteger_compat(L, -2)){
             opt.v = lua_tointeger_compat(L, -2);
         }
-        if( lua_istable(L, -1) ){
+        if(lua_istable(L, -1)){
             throw_error = !(lua_table_to_bson(L, &weights, -1, false, absolute_luaBSONObjects_index, &error ));
             if(throw_error){
                 goto DONE;
@@ -709,7 +722,7 @@ lua_mongo_collection_create_index(lua_State *L)
     collection = (collection_t *) luaL_checkudata(L, 1, "lua_mongoc_collection");
     created = mongoc_collection_create_index(collection->c_collection, &keys, &opt, &error);
 
-    lua_pushstring(L, opt.name); //Return an index name
+    lua_pushstring(L, idxName);
     if(!created){
         throw_error = true;
         goto DONE;
@@ -718,6 +731,7 @@ lua_mongo_collection_create_index(lua_State *L)
 DONE:
     bson_destroy(&keys);
     bson_destroy(&weights);
+    free(idxName);
     if(throw_error){
         luaL_error(L, error.message);
     }
@@ -730,15 +744,33 @@ lua_mongo_collection_drop_index(lua_State *L)
 {
     bool ret = false;
     bool throw_error = false;
+    bool idxTable = false;
 
     collection_t *collection;
     bson_error_t error;
 
-    const char *index_name;
+    char *index_name = "";
     int absolute_luaBSONObjects_index = 2;
     int index_name_index = 3;
 
-    index_name = luaL_checkstring(L, index_name_index);
+    if(lua_isstring(L, index_name_index)){
+        index_name = luaL_checkstring(L, index_name_index);
+    }else if(lua_istable(L, index_name_index)){
+        idxTable = true;
+        lua_pushvalue(L, index_name_index);
+        lua_pushnil(L);
+        while(lua_next(L, -2)){
+            lua_pushvalue(L, -2);
+            const char *key = lua_tostring(L, -1);
+            const char *value = lua_tostring(L, -2);
+            if(strlen(index_name) == 0){
+                asprintf(&index_name, "%s_%s", key, value);
+            }else{
+                asprintf(&index_name, "%s_%s_%s", index_name, key, value);
+            }
+            lua_pop(L, 2);
+        }
+    }
     collection = (collection_t *) luaL_checkudata(L, 1, "lua_mongoc_collection");
 
     ret = mongoc_collection_drop_index(collection->c_collection, index_name, &error);
@@ -750,6 +782,9 @@ lua_mongo_collection_drop_index(lua_State *L)
     }
 
 DONE:
+    if(idxTable){
+        free(index_name);
+    }
     if(throw_error){
         luaL_error(L, error.message);
     }
@@ -769,10 +804,8 @@ lua_mongo_collection_find_indexes(lua_State *L)
     cursor = mongoc_collection_find_indexes(collection->c_collection, &error);
     lua_mongo_cursor_new(L, cursor);
 
-    if(error.code != 0){
+    if(error.code){
         luaL_error(L, error.message);
     }
-
     return 1;
 }
-


### PR DESCRIPTION
Hey Chris,

Thanks for helping me figure this out. I finally feel we are getting somewhere. A lot of this stuff is new to me so you have to forgive me.

The return value from `lua_mongo_collection_create_index()` is now a index name in a situation where a `name` parameter is passed as part of the keys parameter. If the name is not given a default name is generated that is a concatenation of all the keys and their corresponding index types (or directions). This is the behavior that is implemented in PyMongo. In either case you will get a string index name returned from the function.

In addition, the `lua_mongo_collection_drop_index()` can now delete an index in 2 ways. You can pass the original index string name that you received when you created an index, or you can pass the original set of keys that you used to initiate index creation. So in my example file you can delete an index by passing "myindex", or by passing a table `{name = 'text', txt = 'text'}`. This is also consistent with what is done in PyMongo.

I did use `asprintf()` to build up the concatenated string iterating through all the keys that were passed, but wanted to hear from you if it would be ok to use this GNU extension. If you think we should use pure C here, please let me know. Thanks!

