### PR TITLE
Renaming function find_indexes to list_indexes

### DIFF
--- a/c_wrapper/lua-mongoc-collection.c
+++ b/c_wrapper/lua-mongoc-collection.c
@@ -666,7 +666,7 @@ lua_mongo_collection_create_index(lua_State *L)
         lua_getfield(L, options_index, "sparse");
         lua_getfield(L, options_index, "background");
         lua_getfield(L, options_index, "expireAfterSeconds");
-        lua_getfield(L, options_index, "textIndexVersion");
+        lua_getfield(L, options_index, "version");
         lua_getfield(L, options_index, "weights");
 
         used_default_index_name = !lua_isstring(L, -9);
@@ -764,7 +764,7 @@ DONE:
 
 
 int
-lua_mongo_collection_find_indexes(lua_State *L)
+lua_mongo_collection_list_indexes(lua_State *L)
 {
     collection_t *collection;
     mongoc_cursor_t *cursor = NULL;

--- a/c_wrapper/lua-mongoc-collection.h
+++ b/c_wrapper/lua-mongoc-collection.h
@@ -35,7 +35,7 @@ int lua_mongo_collection_aggregate (lua_State *L);
 int lua_mongo_collection_destroy (lua_State *L);
 int lua_mongo_collection_create_index (lua_State *L);
 int lua_mongo_collection_drop_index (lua_State *L);
-int lua_mongo_collection_find_indexes (lua_State *L);
+int lua_mongo_collection_list_indexes (lua_State *L);
 
 static const struct luaL_Reg lua_mongoc_collection_methods[] = {
     { "collection_drop", lua_mongo_collection_drop },
@@ -50,7 +50,7 @@ static const struct luaL_Reg lua_mongoc_collection_methods[] = {
     { "collection_aggregate", lua_mongo_collection_aggregate },
     { "collection_create_index", lua_mongo_collection_create_index },
     { "collection_drop_index", lua_mongo_collection_drop_index },
-    { "collection_find_indexes", lua_mongo_collection_find_indexes },
+    { "collection_list_indexes", lua_mongo_collection_list_indexes },
     { "__gc", lua_mongo_collection_destroy },
     { NULL, NULL },
 };

--- a/examples/indexing.lua
+++ b/examples/indexing.lua
@@ -22,7 +22,7 @@ print('\nInserting sample data:')
 col:insert_many(sample)
 printResult(col:find({}))
 
-local index = col:createIndex({name = 'text', txt = 'text'}, { 
+local index = col:create_index({name = 'text', txt = 'text'}, { 
 	name = 'myindex', 
 	default_language = 'english', 
 	language_override = 'lang', 
@@ -30,7 +30,7 @@ local index = col:createIndex({name = 'text', txt = 'text'}, {
 	sparse = true, 
 	background = true, 
 	expireAfterSeconds = 100, 
-	textIndexVersion = 1,
+	version = 1,
 	weights = {name = 10, txt = 3} 
 } )
 print('\nCreating text search index: ' .. index)
@@ -40,9 +40,9 @@ local res = col:find({['$text'] = {['$search'] = 'berry'}})
 printResult(res)
 
 print('\nRetrieving index: ')
-printResult(col:findIndexes(index))
+printResult(col:list_indexes(index))
 
-print('\nRemoving index: ' .. tostring(col:dropIndex(index) == nil))
+print('\nRemoving index: ' .. tostring(col:drop_index(index) == nil))
 
 print('\nRemoving data.')
 col:drop()

--- a/mongorover/MongoCollection.lua
+++ b/mongorover/MongoCollection.lua
@@ -274,7 +274,7 @@ local MongoCollection = {__mode="k"}
   -- See the MongoDB documentation for a full list of supported options by
 	-- server version.
 	-- @treturn string index name
-	function MongoCollection:createIndex(keys, options)
+	function MongoCollection:create_index(keys, options)
 	    return self.collection_t:collection_create_index(luaBSONObjects, keys, options)
 	end
 
@@ -284,7 +284,7 @@ local MongoCollection = {__mode="k"}
 	-- Example usage at @{indexing.lua}.
 	-- @param index string name or original table with indexed fields and their
 	-- corresponding types.
-	function MongoCollection:dropIndex(index)
+	function MongoCollection:drop_index(index)
 	    return self.collection_t:collection_drop_index(luaBSONObjects, index)
 	end
 
@@ -292,8 +292,8 @@ local MongoCollection = {__mode="k"}
 	-- Get a cursor over the index documents for this collection.
 	-- Example usage at @{indexing.lua}.
 	-- @return A @{MongoCursor} with results.
-	function MongoCollection:findIndexes()
-		local cursor_t = self.collection_t:collection_find_indexes(luaBSONObjects)
+	function MongoCollection:list_indexes()
+		local cursor_t = self.collection_t:collection_list_indexes(luaBSONObjects)
 		return MongoCursor(self, cursor_t)
 	end
 


### PR DESCRIPTION
1. find_ndexes is now renamed to list_indexes
2. createIndex and dropIndex in lua are now create_index and drop_index respectively
3. An option parameter previously called "textIndexVersion" is renamed to "version", because I originally mislabeled the parameter. In reality it is just an index version parameter.
